### PR TITLE
use separate data sources for interface and gateway types of service …

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then commit the updated files.
 | sg\_ingress\_rules | Ingress rules for the VPC Endpoint SecurityGroup(s). Set to empty list to disable default rules. | <pre>list(object({<br>    description      = string<br>    prefix_list_ids  = list(string)<br>    from_port        = number<br>    to_port          = number<br>    protocol         = string<br>    cidr_blocks      = list(string)<br>    ipv6_cidr_blocks = list(string)<br>    security_groups  = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "description": null,<br>    "from_port": 0,<br>    "ipv6_cidr_blocks": null,<br>    "prefix_list_ids": null,<br>    "protocol": "-1",<br>    "security_groups": null,<br>    "to_port": 0<br>  }<br>]</pre> | no |
 | subnet\_ids | Target Subnet ids. | `list(string)` | `[]` | no |
 | tags | A map of tags to add to the VPC Endpoint and to the SecurityGroup(s). | `map(string)` | `{}` | no |
-| vpc\_endpoint\_services | List of AWS Endpoint service names that are used to create VPC Interface Endpoints. Both Gateway and Interface Endpoints are supported. See https://docs.aws.amazon.com/general/latest/gr/rande.html for full list. | `list(string)` | `[]` | no |
+| vpc\_endpoint\_services | List of AWS Endpoint service names that are used to create VPC Interface Endpoints. Both Gateway and Interface Endpoints are supported. See https://docs.aws.amazon.com/general/latest/gr/rande.html for full list. | `object({ interface: list(string), gateway: list(string)})` | `{ interface: [], gateway: []}` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -65,9 +65,17 @@ variable "subnet_ids" {
 }
 
 variable "vpc_endpoint_services" {
-  type        = list(string)
-  description = "List of AWS Endpoint service names that are used to create VPC Interface Endpoints. Both Gateway and Interface Endpoints are supported. See https://docs.aws.amazon.com/general/latest/gr/rande.html for full list."
-  default     = []
+  type = object({
+    interface = list(string)
+    gateway   = list(string)
+  })
+
+  description = "List of VPC Endpoint services separated by type: interface and gateway"
+
+  default = {
+    interface = []
+    gateway   = []
+  }
 }
 
 variable "tags" {
@@ -75,4 +83,3 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
-


### PR DESCRIPTION
…endpoints

Currently, when querying for a list of services to create VPC endpoints for, due to a recent [change in AWS](https://github.com/hashicorp/terraform-provider-aws/issues/17417), we now get
```
"com.amazonaws.us-east-1.s3",
"com.amazonaws.us-east-1.s3",
```
back in the service name list which causes the `data "aws_vpc_endpoint_service"` data source to fail on finding duplicate items. The duplicate items comes from AWS creating endpoints for the s3 service for both interface and gateway types.

This approach requires consuming stacks to upgrade the AWS terraform provider to > 3.1 and utilizing the `service_type` terraform filter.

This PR is borrowing heavily from the upstream provider.